### PR TITLE
Feat: swagger card page API 적용

### DIFF
--- a/src/docs/api/card/card.ts
+++ b/src/docs/api/card/card.ts
@@ -79,4 +79,193 @@ export default {
             },
         },
     },
+    '/card/{userId}/{cardId}': {
+        get: {
+            tags: ['Card'],
+            summary: '단일 영상 가져오기',
+            description: '단일 영상 가져오기 (단일 페이지)',
+            produces: 'application/json',
+            parameters: [
+                {
+                    name: 'userId',
+                    in: 'path',
+                    description: '사용자 아이디',
+                    required: true,
+                },
+                {
+                    name: 'cardId',
+                    in: 'path',
+                    description: '카드 아이디',
+                    required: true,
+                },
+            ],
+            responses: {
+                200: {
+                    description: '사용자 단일 영상 로드 완료',
+                    content: {
+                        'application/json': {
+                            schema: {
+                                type: 'object',
+                                properties: {
+                                    result: {
+                                        type: 'object',
+                                        properties: {
+                                            cardId: {
+                                                type: 'number',
+                                                description: '카드 아이디',
+                                                example: 1,
+                                            },
+                                            userId: {
+                                                type: 'string',
+                                                description: '유저 아이디',
+                                                example: 'test1234',
+                                            },
+                                            albumId: {
+                                                type: 'number',
+                                                description: '해당 카드가 들어있는 앨범 아이디',
+                                                example: 1,
+                                            },
+                                            expressionLabel: {
+                                                type: 'string',
+                                                description: '표정 라벨 데이터',
+                                                example: 'happy',
+                                            },
+                                            comment: {
+                                                type: 'string',
+                                                description: '해당 영상에 남긴 코멘트',
+                                                example: '즐거웠던 하루를 기록하다.',
+                                            },
+                                            thumbnailUrl: {
+                                                type: 'string',
+                                                description: '썸네일 이미지 S3 URL',
+                                                example: 'https://s3.amazonaws.com/test.jpg',
+                                            },
+                                            videoUrl: {
+                                                type: 'string',
+                                                description: '비디오 S3 URL',
+                                                example: 'https://s3.amazonaws.com/test.mp4',
+                                            },
+                                            createdAt: {
+                                                type: 'datetime',
+                                                description: '영상 생성 날짜',
+                                                example: '2022-02-08T00:00:00.000Z',
+                                            },
+                                            updatedAt: {
+                                                type: 'datetime',
+                                                description: '영상 수정 날짜',
+                                                example: '2022-02-08T00:00:00.000Z',
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        delete: {
+            tags: ['Card'],
+            summary: '단일 영상 삭제',
+            description: '단일 영상 삭제 (단일 페이지)',
+            produces: 'application/json',
+            parameters: [
+                {
+                    name: 'userId',
+                    in: 'path',
+                    description: '사용자 아이디',
+                    required: true,
+                },
+                {
+                    name: 'cardId',
+                    in: 'path',
+                    description: '카드 아이디',
+                    required: true,
+                },
+            ],
+            responses: {
+                200: {
+                    description: '사용자 단일 영상 로드 완료',
+                    content: {
+                        'application/json': {
+                            schema: {
+                                type: 'string',
+                                example: 'DELETE CARD OK',
+                                properties: 'DELETE CARD OK',
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        put: {
+            tags: ['Card'],
+            summary: '단일 영상 수정',
+            description: '단일 영상 수정 (단일 페이지)',
+            produces: 'application/json',
+            parameters: [
+                {
+                    name: 'userId',
+                    in: 'path',
+                    description: '사용자 아이디',
+                    required: true,
+                },
+                {
+                    name: 'cardId',
+                    in: 'path',
+                    description: '카드 아이디',
+                    required: true,
+                },
+            ],
+            requestBody: {
+                content: {
+                    'application/json': {
+                        schema: {
+                            properties: {
+                                album_id: {
+                                    type: 'int',
+                                    description: '앨범 아이디',
+                                    example: 1,
+                                },
+                                expression_label: {
+                                    type: 'string',
+                                    description: '표정',
+                                    example: 'happy',
+                                },
+                                comment: {
+                                    type: 'string',
+                                    description: '코멘트',
+                                    example: '즐겁다 즐거워',
+                                },
+                                thumbnail_url: {
+                                    type: 'string',
+                                    description: '썸네일 URL',
+                                    example: 'https://s3.amazonaws.com/test.jpg',
+                                },
+                                video_url: {
+                                    type: 'string',
+                                    description: '비디오 URL',
+                                    example: 'https://s3.amazonaws.com/test.mp4',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            responses: {
+                200: {
+                    description: '사용자 단일 영상 로드 완료',
+                    content: {
+                        'application/json': {
+                            schema: {
+                                type: 'string',
+                                example: 'UPDATE CARD OK',
+                                properties: 'UPDATE CARD OK',
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
 };


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #12 [CD-87]

## **⚡ Content**

- 단일 페이지(/card/{userId}/{cardId})의 카드 get, delete, put API swagger와 연동했습니다
- 현재 swagger 상태 사진입니다
![image](https://user-images.githubusercontent.com/37572031/218307025-cd9db0d4-dba8-4bfa-85fc-ab6c27336043.png)


## **📆 TBD**

- 작업 예정

## **🌟 Point**

- 핵심 내용

## ❓ Question

- 질문


[CD-87]: https://cd-carpe-diem.atlassian.net/browse/CD-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ