### PR TITLE
Feat: 앨범 타이틀 수정 PUT API Swagger 적용, 코드정리

### DIFF
--- a/src/api/card.ts
+++ b/src/api/card.ts
@@ -44,7 +44,7 @@ route.delete('/:userId/:cardId', async (req: Request, res: Response) => {
 });
 
 route.put('/:userId/:cardId', async (req: Request, res: Response) => {
-    let cardDto = req.body.data;
+    let cardDto = req.body;
     cardDto = { user_id: req.params.userId, card_id: req.params.cardId, ...cardDto };
     console.log(cardDto);
 

--- a/src/docs/api/album/album.ts
+++ b/src/docs/api/album/album.ts
@@ -7,6 +7,12 @@ export default {
             produces: 'application/json',
             parameters: [
                 {
+                    name: 'userId',
+                    in: 'path',
+                    description: '사용자 아이디',
+                    required: true,
+                },
+                {
                     name: 'albumId',
                     in: 'path',
                     description: '앨범 아이디',
@@ -24,17 +30,17 @@ export default {
                                     result: {
                                         type: 'object',
                                         properties: {
-                                            albumId: {
+                                            album_id: {
                                                 type: 'number',
                                                 description: '앨범 아이디',
                                                 example: 1,
                                             },
-                                            userId: {
+                                            user_id: {
                                                 type: 'string',
                                                 description: '유저 아이디',
                                                 example: 'test1234',
                                             },
-                                            coverImgUrl: {
+                                            cover_img_url: {
                                                 type: 'string',
                                                 description: '해당 앨범이 들어있는 S3 파일 경로(.jpg)',
                                                 example: 'card-thumbnail/test/2023_02_14/14_41_35.jpg',
@@ -44,18 +50,18 @@ export default {
                                                 description: '해당 앨범 제목',
                                                 example: '취업에 합격해서 기뻤던 한 주',
                                             },
-                                            cardId: {
+                                            card_id: {
                                                 type: 'json',
                                                 description: '해당 앨범에 들어있는 카드 아이디',
                                                 example:
                                                     '{"card1": 1, "card2": 2, "card3": 3, "card4": 4, "card5": 5, "card6": 6, "card7": 7, "card8": 8, "card9": 9, "card10": 10}',
                                             },
-                                            createdAt: {
+                                            created_at: {
                                                 type: 'datetime',
                                                 description: '영상 생성 날짜',
                                                 example: '2022-02-08T00:00:00.000Z',
                                             },
-                                            updatedAt: {
+                                            updated_at: {
                                                 type: 'datetime',
                                                 description: '영상 수정 날짜',
                                                 example: '2022-02-08T00:00:00.000Z',
@@ -76,6 +82,12 @@ export default {
             produces: 'application/json',
             parameters: [
                 {
+                    name: 'userID',
+                    in: 'path',
+                    description: '사용자 아이디',
+                    required: true,
+                },
+                {
                     name: 'albumId',
                     in: 'path',
                     description: '앨범 아이디',
@@ -89,8 +101,68 @@ export default {
                         'application/json': {
                             schema: {
                                 type: 'string',
-                                example: 'DELETE CARD OK',
-                                properties: 'DELETE CARD OK',
+                                example: 'DELETE ALBUM OK',
+                                properties: 'DELETE ALBUM OK',
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        put: {
+            tags: ['Album'],
+            summary: '단일 앨범 수정',
+            description: '단일 앨범 수정 완료',
+            produces: 'application/json',
+            parameters: [
+                {
+                    name: 'userID',
+                    in: 'path',
+                    description: '사용자 아이디',
+                    required: true,
+                },
+                {
+                    name: 'albumId',
+                    in: 'path',
+                    description: '앨범 아이디',
+                    required: true,
+                },
+            ],
+            requestBody: {
+                content: {
+                    'application/json': {
+                        schema: {
+                            properties: {
+                                card_id: {
+                                    type: 'json',
+                                    description: '해당 앨범에 들어있는 카드 아이디',
+                                    example:
+                                        '{"card1": 1, "card2": 2, "card3": 3, "card4": 4, "card5": 5, "card6": 6, "card7": 7, "card8": 8, "card9": 9, "card10": 10}',
+                                },
+                                title: {
+                                    type: 'string',
+                                    description: '타이틀',
+                                    example: 'HSH의 즐거운 날',
+                                },
+                                cover_img_url: {
+                                    type: 'string',
+                                    description: '해당 앨범이 들어있는 S3 파일 경로(.jpg)',
+                                    example: 'card-thumbnail/test/2023_02_14/14_41_35.jpg',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            responses: {
+                200: {
+                    description: '단일 앨범 타이틀 수정 완료',
+                    content: {
+                        'application/json': {
+                            schema: {
+                                type: 'string',
+                                example: 'UPDATE ALBUM OK',
+                                properties: 'UPDATE ALBUM OK',
                             },
                         },
                     },

--- a/src/docs/api/album/album.ts
+++ b/src/docs/api/album/album.ts
@@ -21,7 +21,7 @@ export default {
             ],
             responses: {
                 200: {
-                    description: '단일 앨범 로드 완료',
+                    description: '사용자 단일 앨범 로드 완료',
                     content: {
                         'application/json': {
                             schema: {
@@ -82,7 +82,7 @@ export default {
             produces: 'application/json',
             parameters: [
                 {
-                    name: 'userID',
+                    name: 'userId',
                     in: 'path',
                     description: '사용자 아이디',
                     required: true,
@@ -156,7 +156,7 @@ export default {
             },
             responses: {
                 200: {
-                    description: '단일 앨범 타이틀 수정 완료',
+                    description: '사용자 단일 앨범 타이틀 수정 완료',
                     content: {
                         'application/json': {
                             schema: {

--- a/src/docs/api/card/card.ts
+++ b/src/docs/api/card/card.ts
@@ -24,22 +24,22 @@ export default {
                                     result: {
                                         type: 'object',
                                         properties: {
-                                            cardId: {
+                                            card_id: {
                                                 type: 'number',
                                                 description: '카드 아이디',
                                                 example: 1,
                                             },
-                                            userId: {
+                                            user_id: {
                                                 type: 'string',
                                                 description: '유저 아이디',
                                                 example: 'test1234',
                                             },
-                                            albumId: {
+                                            album_id: {
                                                 type: 'number',
                                                 description: '해당 카드가 들어있는 앨범 아이디',
                                                 example: 1,
                                             },
-                                            expressionLabel: {
+                                            expression_label: {
                                                 type: 'string',
                                                 description: '표정 라벨 데이터',
                                                 example: 'happy',
@@ -49,22 +49,22 @@ export default {
                                                 description: '해당 영상에 남긴 코멘트',
                                                 example: '즐거웠던 하루를 기록하다.',
                                             },
-                                            thumbnailUrl: {
+                                            thumbnail_url: {
                                                 type: 'string',
                                                 description: '썸네일 이미지 S3 URL',
                                                 example: 'https://s3.amazonaws.com/test.jpg',
                                             },
-                                            videoUrl: {
+                                            video_url: {
                                                 type: 'string',
                                                 description: '비디오 S3 URL',
                                                 example: 'https://s3.amazonaws.com/test.mp4',
                                             },
-                                            createdAt: {
+                                            created_at: {
                                                 type: 'datetime',
                                                 description: '영상 생성 날짜',
                                                 example: '2022-02-08T00:00:00.000Z',
                                             },
-                                            updatedAt: {
+                                            updated_at: {
                                                 type: 'datetime',
                                                 description: '영상 수정 날짜',
                                                 example: '2022-02-08T00:00:00.000Z',
@@ -110,22 +110,22 @@ export default {
                                     result: {
                                         type: 'object',
                                         properties: {
-                                            cardId: {
+                                            card_id: {
                                                 type: 'number',
                                                 description: '카드 아이디',
                                                 example: 1,
                                             },
-                                            userId: {
+                                            user_id: {
                                                 type: 'string',
                                                 description: '유저 아이디',
                                                 example: 'test1234',
                                             },
-                                            albumId: {
+                                            album_id: {
                                                 type: 'number',
                                                 description: '해당 카드가 들어있는 앨범 아이디',
                                                 example: 1,
                                             },
-                                            expressionLabel: {
+                                            expression_label: {
                                                 type: 'string',
                                                 description: '표정 라벨 데이터',
                                                 example: 'happy',
@@ -135,22 +135,22 @@ export default {
                                                 description: '해당 영상에 남긴 코멘트',
                                                 example: '즐거웠던 하루를 기록하다.',
                                             },
-                                            thumbnailUrl: {
+                                            thumbnail_url: {
                                                 type: 'string',
                                                 description: '썸네일 이미지 S3 URL',
                                                 example: 'https://s3.amazonaws.com/test.jpg',
                                             },
-                                            videoUrl: {
+                                            video_url: {
                                                 type: 'string',
                                                 description: '비디오 S3 URL',
                                                 example: 'https://s3.amazonaws.com/test.mp4',
                                             },
-                                            createdAt: {
+                                            created_at: {
                                                 type: 'datetime',
                                                 description: '영상 생성 날짜',
                                                 example: '2022-02-08T00:00:00.000Z',
                                             },
-                                            updatedAt: {
+                                            updated_at: {
                                                 type: 'datetime',
                                                 description: '영상 수정 날짜',
                                                 example: '2022-02-08T00:00:00.000Z',
@@ -229,17 +229,17 @@ export default {
                                 },
                                 expression_label: {
                                     type: 'string',
-                                    description: '표정',
+                                    description: '녹화 영상 최대 감정 표정',
                                     example: 'happy',
                                 },
                                 comment: {
                                     type: 'string',
-                                    description: '코멘트',
+                                    description: '녹화 영상 코멘트',
                                     example: '즐겁다 즐거워',
                                 },
                                 thumbnail_url: {
                                     type: 'string',
-                                    description: '썸네일 URL',
+                                    description: '녹화 영상 썸네일 URL',
                                     example: 'https://s3.amazonaws.com/test.jpg',
                                 },
                                 video_url: {


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #12 #17 #27 #28 #32 [CD-28] [CD-95]

## **⚡ Content**

- 앨범 타이틀 수정 PUT API Swagger 적용 완료
- 카드 Swagger 전체 정리 (responses 통일, 관련 설명 내용 수정)
- 앨범 Swagger GET, DELETE 내용 수정 (userId param 받기, responses 내용 수정)

## **📆 TBD**

- 프론트 card put 수정
**@olive-su 가 swagger 보고 @olive-su 가 짠 API 네이밍 바꾸기** => **확실하게 정하고 갑시다.**
~@XxoSio 가 가위바위보 짐....... 명서세 내놔!!!!~

## **🌟 Point**

- Swagger와 프론트 내용 통일
   -> card에서 req.body.data로 요청이 넘어옴
   -> Swagger와 album에서는 req.body로 요청이 넘어옴
   => 이를 req.body로 통일! => 프론트 card put 수정해야함

## ❓ Question

- 질문


[CD-28]: https://cd-carpe-diem.atlassian.net/browse/CD-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CD-95]: https://cd-carpe-diem.atlassian.net/browse/CD-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ